### PR TITLE
enhancement/bump_dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 [versions]
 
 #Plugins
-agpVersionPlugin = "8.1.2"
+agpVersionPlugin = "8.2.0"
 
 #Global
-kotlinVersion = "1.9.10"
+kotlinVersion = "1.9.21"
 applicationId = "me.inassar"
 
 #Android
@@ -14,25 +14,24 @@ targetSdk = "34"
 minSdk = "24"
 versionCode = "1"
 versionName = "1.0.0"
-composeCompiler = "1.5.3"
-activityCompose = "1.7.2"
+composeCompiler = "1.5.4"
+activityCompose = "1.8.2"
 appcompat = "1.6.1"
 coreKtx = "1.12.0"
 
 #Third Party
-kamelImageLoaderVersion = "0.7.3"
-voyagerVersion = "1.0.0-rc07"
-calfAdaptiveUiVersion = "0.2.0"
+kamelImageLoaderVersion = "0.9.1"
+voyagerVersion = "1.0.0"
+calfAdaptiveUiVersion = "0.3.0"
 napierVersion = "2.6.1"
 buildKonfigVersion = "0.14.0"
 
 #Multiplatform
-composeMultiplatformVersion = "1.5.3"
-ktorVersion = "2.3.5"
+composeMultiplatformVersion = "1.5.11"
+ktorVersion = "2.3.7"
 kotlinxCoroutines = "1.7.3"
 kotlinxDateTime = "0.4.0"
-koinVersion = "3.5.0"
-koinAndroidXCompose = "3.5.0"
+koinVersion = "3.5.3"
 
 # Define the libraries
 [libraries]
@@ -57,19 +56,20 @@ appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat"
 composeActivity = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatformVersion" }
 
-composeUI = { module = "androidx.compose.ui:ui", version.ref = "composeMultiplatformVersion" }
-composeUtil = { module = "androidx.compose.ui:ui-util", version.ref = "composeMultiplatformVersion" }
-composeTooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatformVersion" }
-composeMaterialIcons = { module = "androidx.compose.material:material-icons-extended", version.ref = "composeMultiplatformVersion" }
+composeUI = { module = "androidx.compose.ui:ui", version.ref = "composeCompiler" }
+composeUtil = { module = "androidx.compose.ui:ui-util", version.ref = "composeCompiler" }
+composeTooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "composeCompiler" }
+composeMaterialIcons = { module = "androidx.compose.material:material-icons-extended", version.ref = "composeCompiler" }
 
 #ThirdParty
 koinCore = { module = "io.insert-koin:koin-core", version.ref = "koinVersion" }
 koinTest = { module = "io.insert-koin:koin-test", version.ref = "koinVersion" }
 koinTestJUnit4 = { module = "io.insert-koin:koin-test-junit4", version.ref = "koinVersion" }
 koinAndroid = { module = "io.insert-koin:koin-android", version.ref = "koinVersion" }
-koinCompose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koinAndroidXCompose" }
+koinCompose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koinVersion" }
 kamelImageLoader = { module = "media.kamel:kamel-image", version.ref = "kamelImageLoaderVersion" }
 voyagerNavigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyagerVersion" }
+voyagerScreenModel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyagerVersion" }
 voyagerTransitions = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyagerVersion" }
 calfAdaptiveUi = { module = "com.mohamedrejeb.calf:calf-ui", version.ref = "calfAdaptiveUiVersion" }
 napier = { module = "io.github.aakira:napier", version.ref = "napierVersion" }
@@ -86,6 +86,7 @@ multiplatformLibs = [
     "koinCore",
     "kamelImageLoader",
     "voyagerNavigator",
+    "voyagerScreenModel",
     "voyagerTransitions",
     "calfAdaptiveUi",
     "napier"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Dec 26 11:35:19 AST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/shared/src/commonMain/kotlin/me/inassar/features/feature/presentation/manipulator/FeatureViewModel.kt
+++ b/shared/src/commonMain/kotlin/me/inassar/features/feature/presentation/manipulator/FeatureViewModel.kt
@@ -1,8 +1,9 @@
 package me.inassar.features.feature.presentation.manipulator
 
 import cafe.adriel.voyager.core.model.StateScreenModel
-import cafe.adriel.voyager.core.model.coroutineScope
+import cafe.adriel.voyager.core.model.screenModelScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import me.inassar.common.network.ResponseResource
@@ -14,7 +15,8 @@ import org.koin.core.component.inject
 /**
  * Created by Ahmed Nassar on 5/27/23.
  */
-class FeatureModel : StateScreenModel<FeatureState>(initialState = FeatureState.Loading), KoinComponent {
+class FeatureModel : StateScreenModel<FeatureState>(initialState = FeatureState.Loading),
+    KoinComponent {
     private val repository: FeatureRepository by inject()
 
     fun onEvent(events: FeatureEvents) {
@@ -25,7 +27,7 @@ class FeatureModel : StateScreenModel<FeatureState>(initialState = FeatureState.
 
     private fun getFeatures() {
         // We should specify dispatchers to be on default always, as this is the only dispatcher that supports desktop
-        coroutineScope.launch(Dispatchers.Default) {
+        screenModelScope.launch(Dispatchers.Default) {
             repository.getProducts().collect { result ->
                 when (result) {
                     is ResponseResource.Error ->


### PR DESCRIPTION
- Bump android gradle version from 8.1.2 to 8.2.0
- Bump kotlin version from 1.9.10 to 1.9.21
- Bump compose compiler version from 1.5.3 to 1.5.4
- Bump activity compose version from 1.7.2 to 1.8.2
- Bump Kamel Image loader version from 0.7.3 to 0.9.1
- Bump voyager version from 1.0.0-rc07 to 1.0.0
- Bump calf adaptive ui version from 0.2.0 to 0.3.0
- Bump compose multiplatform version from 1.5.3 to 1.5.11
- Bump ktor version from 2.3.5 to 2.3.7
- Bump koin version from 3.5.0  to 3.5.3